### PR TITLE
Remove vestigial path for streaming EPP metrics

### DIFF
--- a/core/src/main/java/google/registry/env/common/backend/WEB-INF/web.xml
+++ b/core/src/main/java/google/registry/env/common/backend/WEB-INF/web.xml
@@ -13,11 +13,6 @@
     <load-on-startup>1</load-on-startup>
   </servlet>
 
-  <servlet-mapping>
-    <servlet-name>backend-servlet</servlet-name>
-    <url-pattern>/_dr/task/metrics</url-pattern>
-  </servlet-mapping>
-
   <!-- RDE -->
 
   <!--


### PR DESCRIPTION
The relevant action was deleted last year here: https://github.com/google/nomulus/commit/218c4517ebf05fae6fe74bf9b011fbc14754f435

This removes the final hanging piece.